### PR TITLE
Improved support for Contacts and Invoices

### DIFF
--- a/src/FreeAgent/Customer.php
+++ b/src/FreeAgent/Customer.php
@@ -49,11 +49,20 @@ class Customer extends AccountingCustomer
         $data   = $single ? [ $data->contact ] : $data->contacts;
         foreach ( $data as $object )
         {
+            // Not all contacts will have a first and/or last name, if none was specified
+            $contact = '';
+            if ( isset( $object->first_name ) ) {
+                $contact .= $object->first_name;
+            }
+            if ( isset( $object->last_name ) ) {
+                $contact .= ( ! empty( $contact ) ? ' ' : '' ) . $object->last_name;
+            }
+
             $class = __CLASS__;
             $customer = new $class;
             $customer->id       = basename( $object->url );
             $customer->name     = $object->organisation_name;
-            $customer->contact  = $object->first_name . ' ' . $object->last_name;
+            $customer->contact  = $contact;
             $customer->email    = isset( $object->email )    ? $object->email    : null;
             $customer->phone    = isset( $object->phone )    ? $object->phone    : null;
             $customer->website  = isset( $object->website )  ? $object->website  : null;
@@ -67,7 +76,7 @@ class Customer extends AccountingCustomer
     }
     
     /*
-     * Get unique id after object creationg
+     * Get unique id after object creation
      *
      */
     public static function uid( \Accounting\Interfaces\Model $model, $data )

--- a/src/FreeAgent/Invoice.php
+++ b/src/FreeAgent/Invoice.php
@@ -29,15 +29,28 @@ class Invoice extends AccountingInvoice
         	'payment_terms_in_days' => $this->terms,
         	'contact'               => isset( $this->customer->id ) ? $this->customer->id : $this->customerId,
         	'comments'              => $this->po ? 'PO: ' . $this->po : $this->notes,
+            'currency'              => ( isset( $this->currency ) ? $this->currency : '' ),
         	'invoice_items'         => array()
         );
+
+        // If EC Status is defined, set it now
+        if ( isset( $this->ec_status ) ) {
+            $data['ec_status'] = $this->ec_status;
+        }
+
+        // If Place of Supply is defined, set it now
+        if ( isset( $this->place_of_supply ) ) {
+            $data['place_of_supply'] = $this->place_of_supply;
+        }
+
         foreach ( $this->items as $item )
         {
         	$data['invoice_items'][] = array(
-            	'description' => $item->description,
-            	'quantity'    => $item->quantity,
-            	'item_type'   => 'Hours',
-            	'price'       => $item->price,
+            	'description'      => $item->description,
+            	'quantity'         => $item->quantity,
+            	'item_type'        => $item->type ? $item->type : 'Hours',
+            	'price'            => $item->price,
+                'sales_tax_rate'   => $item->tax_rate ? $item->tax_rate : 0,
         	);
         }
         return [ 'invoice' => $data ];
@@ -73,6 +86,7 @@ class Invoice extends AccountingInvoice
                 	$item = new Item;
                 	$item->description = $invoiceItem->description;
                 	$item->quantity    = $invoiceItem->quantity;
+                    $item->item_type   = $invoiceItem->type;
                 	$item->price       = $invoiceItem->price;	
                 	$invoice->items[] = $item;
                 }

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -11,17 +11,21 @@ class InvoiceTest extends TestCase
         $customers = $this->api->find( 'customer' );
         
         $invoice = new Invoice;
-        $invoice->issued   = '2015-07-02 22:44:00';
-        $invoice->due      = '2015-08-02 22:44:00';
-        $invoice->terms    = 30;
-        $invoice->customer = $customers[0];
-        $invoice->currency = 'GBP';
-        $invoice->notes    = 'Project #P123';
+        $invoice->issued            = '2015-07-02 22:44:00';
+        $invoice->due               = '2015-08-02 22:44:00';
+        $invoice->terms             = 30;
+        $invoice->customer          = $customers[0];
+        $invoice->currency          = 'GBP';
+        $invoice->ec_status         = 'Non-EC';
+        $invoice->place_of_supply   = 'GB';
+        $invoice->notes             = 'Project #P123';
         
         $item = new Item;
-        $item->description = 'Example';
-        $item->quantity    = 10;
-        $item->price       = 100;
+        $item->type         = 'Products';
+        $item->description  = 'Example';
+        $item->quantity     = 10;
+        $item->price        = 100;
+        $item->tax_rate     = 20;
         
         $invoice->items[] = $item;
         


### PR DESCRIPTION
**Contacts**

- Check for a Contact's First and Last Name when fetching a contact.  If they're not specified in FreeAgent, FreeAgent won't return the first_name and last_name keys, therefore breaking.

**Invoices**

- Currency wasn't being sent through to FreeAgent, despite having the option to set it
- EC Status and Place of Supply support added

**Invoices Items**

- Item Type support added (Hours, Products etc)
- Sales Tax support added (e.g. 20 = add 20% to the item price)